### PR TITLE
Add a version flag to the help text

### DIFF
--- a/jungle/__init__.py
+++ b/jungle/__init__.py
@@ -1,1 +1,3 @@
 # -*- coding: utf-8 -*-
+
+__version__ = '0.1.7'

--- a/jungle/cli.py
+++ b/jungle/cli.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 import click
 
+from jungle import __version__
+
 
 class JungleCLI(click.MultiCommand):
 
@@ -16,7 +18,7 @@ class JungleCLI(click.MultiCommand):
         return mod.cli
 
 
-cli = JungleCLI(help='aws operation cli')
+cli = JungleCLI(help="aws operation cli (v{})".format(__version__))
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,22 @@
 # -*- coding: utf-8 -*-
 """AWS operations by cli should be simpler."""
+import re
+
 from setuptools import find_packages, setup
+
+
+# Taken from "kennethreitz/requests": http://git.io/vcuY8
+version = ''
+with open('jungle/__init__.py', 'r') as fd:
+    version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
+                        fd.read(), re.MULTILINE).group(1)
+
+if not version:
+    raise RuntimeError('Cannot find version information')
 
 setup(
     name='jungle',
-    version='0.1.7',
+    version=version,
     url='https://github.com/achiku/jungle',
     license='MIT',
     author='Akira Chiku',


### PR DESCRIPTION
This moves the version identifier to `jungle/__init__.py` so that it can be imported, and used in other parts of the code, namely the `--help` text. This is useful when determining if there's a newer version of `jungle` available.

The code for finding the version identifier was taken from [kennethreitz/requests](http://git.io/vcuY8).

I was thinking that it might be good to have a command option for the version number as well, but I'm not familiar enough with the click library to implement it correctly. It would work like so:
```bash
$ jungle --version
0.1.7
```