### PR TITLE
fixes UnicodeEncodeError

### DIFF
--- a/jungle/ec2.py
+++ b/jungle/ec2.py
@@ -6,6 +6,8 @@ import boto3
 import botocore
 import click
 
+reload(sys)
+sys.setdefaultencoding("utf-8")
 
 def format_output(instances, flag):
     """return formatted string for instance"""


### PR DESCRIPTION
Fix this when AWS_DEFAULT_REGION is set to a region different from sa-east-1

Traceback (most recent call last):
File "/usr/local/bin/jungle", line 9, in <module>
load_entry_point('jungle==0.6.0', 'console_scripts', 'jungle')()
File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 716, in **call**
return self.main(_args, *_kwargs)
File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 696, in main
rv = self.invoke(ctx)
File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 1060, in invoke
return _process_result(sub_ctx.command.invoke(sub_ctx))
File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 1060, in invoke
return _process_result(sub_ctx.command.invoke(sub_ctx))
File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 889, in invoke
return ctx.invoke(self.callback, *_ctx.params)
File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 534, in invoke
return callback(_args, **kwargs)
File "/usr/local/lib/python2.7/dist-packages/jungle/ec2.py", line 60, in ls
out = format_output(instances, list_formatted)
File "/usr/local/lib/python2.7/dist-packages/jungle/ec2.py", line 21, in format_output
tag_name, i.state['Name'], i.id, i.private_ip_address, str(i.public_ip_address)))
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe3' in position 5: ordinal not in range(128)
